### PR TITLE
Clarified that this is, in fact, the MIT license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Part of this work is based on JSON.sh, available at https://github.com/dominictarr/JSON.sh
 
 The license of that project is printed below:
+The MIT License - http://www.opensource.org/licenses/mit-license.php
 Copyright (c) 2011 Dominic Tarr
 
 Permission is hereby granted, free of charge,


### PR DESCRIPTION
I skimmed this and then compared the first few sentences with MIT license, this seems to be directly copied.

Please accept this change labeling it as the MIT license.
