### PR TITLE
Added a Makefile for 'make install'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+SRC_FILE := ticktick.sh
+BASH_PATH := $(shell which bash)
+INSTALL_PATH := $(shell dirname $(BASH_PATH))
+
+default: help
+
+help:
+	@echo
+	@echo 'make test - Run the TickTick test suite'
+	@echo 'make install - Install ticktick.sh (next to bash)'
+	@echo
+
+test:
+	(cd tests; ./runall.sh)
+
+install:
+	cp $(SRC_FILE) $(INSTALL_PATH)
+	chmod +x $(INSTALL_PATH)/$(SRC_FILE)


### PR DESCRIPTION
by installing ticktick.sh in the PATH, you can have this usage:

```
. `which ticktick.sh`
```

I like to do this with my bash modules so that I can use them from any script (like Perl or Python modules).
