### PR TITLE
Added CLI options to tickVars to make it more machine friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Miscellaneous
 
 #### tickVars - see the currently defined variables
  * Show all variables: You can see the current values defined in the TickTick world with the `tickVars` routine.
+ * If you don't like the output, there are some options to customize it. Try `tickVars -h` for more information.
 
 #### tickReset - clear the currently defined variables
  * Clear all variables: You can erace any JSON you have created/imported with the `tickReset` routine.

--- a/ticktick.sh
+++ b/ticktick.sh
@@ -425,9 +425,38 @@ if [[ $__tick_var_tokenized ]]; then
   }
 
   tickVars() {
-    echo "@ Line `caller | sed s/\ NULL//`:"
-    set | sed -nr /^__tick_data_/s/__tick_data_/"  "/p
-    echo
+    local tick_vars_opt='' sup_ln_number='' sup_trailing_nl='' indent="  "
+
+    # Process commandline flags
+    OPTIND=1
+    while getopts ':hiln' tick_vars_opt; do
+      case $tick_vars_opt in
+        h)
+        cat 1>&2 <<-"ENDHELP"
+		USAGE: tickVars [-hiln]
+		-h: Emit this usage information.
+		-i: Suppress the indentation that usually precedes each line of output.
+		-l: Suppress the line number information that usually appears at the beginning of output.
+		-n: Suppress the blank line which usually prints at the end of output.
+		ENDHELP
+        exit 0
+        ;;
+        i)
+        indent=""
+        ;;
+        l)
+        sup_ln_number=yes
+        ;;
+        n)
+        sup_trailing_nl=yes
+        ;;
+        esac
+      done
+
+    [[ -z "$sup_ln_number" ]] && echo "@ Line `caller | sed s/\ NULL//`:"
+    set | grep ^__tick_data | sed s/__tick_data_/"$indent"/
+    [[ -z "$sup_trailing_nl" ]] && echo
+    return 0
   }
 
   tickReset() {

--- a/ticktick.sh
+++ b/ticktick.sh
@@ -454,7 +454,7 @@ if [[ $__tick_var_tokenized ]]; then
       done
 
     [[ -z "$sup_ln_number" ]] && echo "@ Line `caller | sed s/\ NULL//`:"
-    set | grep ^__tick_data | sed s/__tick_data_/"$indent"/
+    set | sed -nr /^__tick_data_/s/^__tick_data_/"$indent"/p
     [[ -z "$sup_trailing_nl" ]] && echo
     return 0
   }


### PR DESCRIPTION
Added some command line opts to tickVars, to make its output less friendly to most humans, but easier for code to parse (and because I just prefer it looking like this--maybe others do, too). Included a brief note in README.

Doesn't change any current behavior; it defaults to the way it always did things.

The options added are:
		-h: Emit usage information.
		-i: Suppress the indentation that usually precedes each line of output.
		-l: Suppress the line number information that usually appears at the beginning of output.
		-n: Suppress the blank line which usually prints at the end of output.