### PR TITLE
(Fixed) Unquoted string safing in README example (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Inline Parsing
       echo "  The ``people.Engineering.length()`` Employees listed are:"
 
       for employee in ``people.Engineering.items()``; do
-        printf "    - %s\n" ${!employee}
+        printf "    - %s\n" "${!employee}"
       done
 
       echo 


### PR DESCRIPTION
The employees example in the README, uses an unquoted string expansion in the printf. The same example in example.sh quotes this string.

This problem caused issue #41 , most likely, because that user just followed the README without knowing why.

This PR fixes the README example by quoting the string dereference like the example.sh version does.