### PR TITLE
Created a tickReset function, to reset TickTick to initial state...

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Miscellaneous
 #### tickVars - see the currently defined variables
  * Show all variables: You can see the current values defined in the TickTick world with the `tickVars` routine.
 
+#### tickReset - clear the currently defined variables
+ * Clear all variables: You can erace any JSON you have created/imported with the `tickReset` routine.
+
 #### __tick_var_debug - See the interim bash code
  * Dry run (display compiled code): TickTick is a mini-compiler that emits bash. If you declare `extern __tick_var_debug=1` at the top of your code, then the code will not run but instead print what it would have run.
 

--- a/ticktick.sh
+++ b/ticktick.sh
@@ -429,6 +429,12 @@ if [[ $__tick_var_tokenized ]]; then
     set | grep ^__tick_data | sed s/__tick_data_/"  "/
     echo
   }
+
+  tickReset() {
+    for var in     `set | sed -nr 's/^(__tick_data_[^=]+).*/\1/p'`
+      do unset "$var"
+    done
+  }
 else 
   __tick_fun_tokenize
 fi


### PR DESCRIPTION
Created a tickReset function, to reset TickTick to initial state with no JSON. Mentioned in README.

I think it should be safe to use: it uses the same kind of unsetting of __tick_data_ vars that delete() does, as far as I can tell.
Appears to work for me.