### PR TITLE
Remove an unnecessary grep from tickVars(); put functionality into existing sed

### DIFF
--- a/ticktick.sh
+++ b/ticktick.sh
@@ -426,7 +426,7 @@ if [[ $__tick_var_tokenized ]]; then
 
   tickVars() {
     echo "@ Line `caller | sed s/\ NULL//`:"
-    set | grep ^__tick_data | sed s/__tick_data_/"  "/
+    set | sed -nr /^__tick_data_/s/__tick_data_/"  "/p
     echo
   }
 else 


### PR DESCRIPTION
In tickVars(), there was a pipe including grep and sed. Grep was only picking lines for the call to sed.
Sed can do that itself, and doing it that way saves an extra program launch.