### PR TITLE
Fix debug advice in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Miscellaneous
  * Clear all variables: You can erace any JSON you have created/imported with the `tickReset` routine.
 
 #### __tick_var_debug - See the interim bash code
- * Dry run (display compiled code): TickTick is a mini-compiler that emits bash. If you declare `export __tick_var_debug=1` at the top of your code, then the code will not run but instead print what it would have run.
+ * Dry run (display compiled code): TickTick is a mini-compiler that emits bash. If you declare `export __tick_var_debug=1` at the top of your code (before you source ticktick.sh), then the code will not run but instead print what it would have run.
 
 Bash variables ($) in JSON
 ---


### PR DESCRIPTION
README said to use "extern" to set the debugging variable; there is no such builtin.
Also the instruction to include it at the top of your code was not absolutely clear on whether it should be above or below the source of TickTick (above, I gather from testing).
Fixed both herewith.