### PR TITLE
Run shellcheck and some more manual fixes

### DIFF
--- a/ticktick.sh
+++ b/ticktick.sh
@@ -445,7 +445,7 @@ if [[ $__tick_var_tokenized ]]; then
 		-n: Suppress the blank line which usually prints at the end of output.
 		ENDHELP
 	[[ $tick_vars_opt == 'h' ]]
-        exit
+        return
         ;;
       esac
     done


### PR DESCRIPTION
* ARGV is now an array. Should fix #32.
* Quotes and stuff, also in generated code.
* Not using `...` is a good idea because it effs up badly when you nest them. It's also in shellcheck.
* Catch bad args in tickVars. And don't exit on help -- you are a function, act like one.

* * *

POSIX interaction, in case people want it later:
* No arrays, but we aren't gonna do the transpiling anyways.
* No `+=`, so it's gonna be dreadfully slow for long args. Remember the quadratic string append stuff in JS? Yeah it's exactly that.
* No `${var/pat/sub}`, so dreadfully slow again. Prefix and suffix trimming is available though.
* No `(( ... ))`, but `[ "$(( ... ))" -ne 0 ]` is the same. Except for `++`.
* No `<<<`, so I am effing myself up.

In addition, [`echo` is a wack](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html), but we can always roll our own with `printf`. 